### PR TITLE
Fix conversion to pyboolnet primes

### DIFF
--- a/biolqm/__init__.py
+++ b/biolqm/__init__.py
@@ -256,8 +256,8 @@ def to_pint(model, simplify=True):
 def to_pyboolnet(model):
     bnetfile = new_output_file("bnet")
     assert save(model, bnetfile, "bnet")
-    PyBoolNet = import_colomoto_tool("PyBoolNet")
-    bn = PyBoolNet.FileExchange.bnet2primes(bnetfile)
+    from pyboolnet.file_exchange import bnet2primes
+    bn = bnet2primes(bnetfile)
     return bn
 
 def to_booleannet(model, mode='async'):


### PR DESCRIPTION
I was updating an old notebook, and found out this was not working anymore. 
I couldn't find a way to use import_colomoto_tool (although maybe I didn't try enough), but at least it's working. 